### PR TITLE
Option to remove wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - oval compiler related code located under /lib/compilers
 - `registerTag` remove usage of `document.registerTag`
 - `baseTag` all props from parent component go to `tag.props`
-- add option to strip component's parent tag
+- add option to strip component's parent tag `tag.keepParentTag`, defaults to `true`
 
 
 ## [1.0.0] - 2016-07-27

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -7,6 +7,7 @@ module.exports = function (oval) {
     tag.props = {}
     tag.childTags = []
     tag.id = Math.random()
+    tag.keepParentTag = true
     tag.lifecycle = {
       constructed: true,
       mounted: false
@@ -40,17 +41,16 @@ module.exports = function (oval) {
       }
 
       this.view = this.render(this.createElement)
+      if (!this.keepParentTag) {
+        this.view = this.view.firstChild
+      }
 
       if (!this.lifecycle.mounted) {
         this.emit('mount')
       }
 
       this.emit('update')
-      if (this.keepParentTag || this.lifecycle.mounted) {
-        oval.updateElement(this.root, this.view)
-      } else {
-        this.root = oval.updateElement(this.root, this.view, {removeParentTag: true})
-      }
+      this.root = oval.updateElement(this.root, this.view)
 
       var newTags = oval.mountAll('*', this.root)
       for (var i = 0; i < this.childTags.length; i++) {

--- a/lib/update-element.js
+++ b/lib/update-element.js
@@ -7,11 +7,6 @@ module.exports = function updateElement (node, nodeTemplate, opts) {
     if (!opts.onBeforeElUpdated) opts.onBeforeElUpdated = copier
   }
 
-  if (opts.removeParentTag) {
-    nodeTemplate = nodeTemplate.firstChild
-    delete opts.removeParentTag
-  }
-
   return morphdom(node, nodeTemplate, opts)
 
   // morphdom only copies attributes. we decided we also wanted to copy events

--- a/tests/oval/keep-parent-tag.test.js
+++ b/tests/oval/keep-parent-tag.test.js
@@ -1,0 +1,61 @@
+describe('keep parent tag', function () {
+  var oval
+  var customTagInstance
+
+  var Tag = function (tagName, root) {
+    oval.BaseTag(this, tagName, root)
+    this.keepParentTag = false
+    this.testValue = 1
+  }
+  Tag.prototype.render = function (createElement) {
+    return createElement(this.tagName, {},
+      createElement('div', {},
+        createElement('child-tag', {
+          'ref-custom-value': {test: this.testValue}
+        })
+      )
+    )
+  }
+
+  var ChildTag = function (tagName, root) {
+    oval.BaseTag(this, tagName, root)
+    this.keepParentTag = false
+  }
+  ChildTag.prototype.render = function (createElement) {
+    return createElement(this.tagName, {}, createElement('span', {class: this.props['custom-value'].test}))
+  }
+
+  before(function () {
+    window.document.body.innerHTML = ''
+    var plasma = {}
+    oval = require('../../index')
+    oval.registeredTags = []
+    oval.init(plasma)
+    oval.registerTag('custom-tag', Tag)
+    oval.registerTag('child-tag', ChildTag)
+  })
+
+  it('mount and renders', function () {
+    var el = document.createElement('custom-tag')
+    document.body.appendChild(el)
+    var tag = oval.mountAt(el, 'custom-tag')
+
+    expect(document.body.children.length).to.eq(1)
+    expect(document.body.children[0].tagName).to.eq('DIV')
+    expect(el).to.not.eq(tag.root)
+    expect(document.body.children[0].children[0].tagName).to.eq('SPAN')
+    expect(document.body.children[0].children[0].attributes.class.value).to.eq('1')
+
+    customTagInstance = tag
+  })
+
+  it('re-renders', function () {
+    customTagInstance.testValue = 2
+    customTagInstance.update()
+
+    expect(document.body.children.length).to.eq(1)
+    expect(document.body.children[0].tagName).to.eq('DIV')
+    expect(document.body.children[0].children[0].tagName).to.eq('SPAN')
+    expect(document.body.children[0].children[0].attributes.class.value).to.eq('2')
+  })
+})


### PR DESCRIPTION
# Remove Wrapper Update

Added option to choose weather you want to keep/remove the wrapping tag of a component.

**Parent tag is not rendered by default**

if you want component's parent tag **not** to be stripped every time the component is rendered, you can now set `tag.keepParentTag`

keeping parent tag:

``` html
<app>
  <script>
    require('./another-component')
    this.keepParentTag = true
  </script>
  <div>
    <ul>
        <another-component ... />
    </ul>
  </div>
</app>
```

not keeping parent tag

``` html
<another-component>
  <li>
    <a>
      ...
    </a>
  </li>
</another-component>
```
