### PR TITLE
42 directives should know their name used in props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [major.minor.patch] - YYYY-MM-DD
+
+### Fixed
+
+- oval `if` control statement edge case with inner tags having the same name of the openning one
+
 ## [3.0.0] - 2016-08-03
 
 ### API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [major.minor.patch] - YYYY-MM-DD
 
+### Improved
+
+- `BaseTag.injectDirectives()` - every directive accepts `tag` and `directiveName`
+
 ### Fixed
 
 - oval `if` control statement edge case with inner tags having the same name of the openning one

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ The following tag won't re-render itself and will not be replaced by parent tag 
 A directive is the following module:
 
 ```js
-module.exports = function (tag) {
+module.exports = function (tag, directiveName) {
   return {
     preCreate: function (createElement, tagName, props, ...children) {
       // ... augment props

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -63,7 +63,7 @@ module.exports = function (oval) {
       for (var key in directivesMap) {
         if (tag.directives[key]) throw new Error(key + ' directive already injected')
         tag.directives[key] = directivesMap[key]
-        argumentedDirectives[key] = directivesMap[key](tag)
+        argumentedDirectives[key] = directivesMap[key](tag, key)
       }
       this.createElement = oval.createElement(argumentedDirectives)
     }

--- a/lib/compilers/tag-control-statements.js
+++ b/lib/compilers/tag-control-statements.js
@@ -52,12 +52,27 @@ var parseIfs = function (lines) {
       var attributes = extractAttributes(statement, parsedLine)
 
       if (lines[i].indexOf('/>') === -1 && lines[i].indexOf('</' + nodeName + '>') === -1) {
+        // buffer lines between start and end closing tag when not on the same line
         var buffer = []
+        var innerNodeNameCount = 0
+
         for (var k = i + 1; k < lines.length; k++) {
-          if (lines[k].indexOf('</' + nodeName + '>') !== -1) {
-            lines.splice(k, 1)
-            break
+          // found a line with the same node name as the opening tag
+          if (lines[k].indexOf('<' + nodeName) !== -1) {
+            innerNodeNameCount += 1
           }
+          // found a line with a name of the closing tag
+          if (lines[k].indexOf('</' + nodeName + '>') !== -1) {
+            if (innerNodeNameCount > 0) {
+              // the line has closing tag of a inner childrens
+              innerNodeNameCount -= 1
+            } else {
+              // the line is the closing tag of the statement
+              lines.splice(k, 1)
+              break
+            }
+          }
+          // buffer lines and remove them from original source
           buffer.push(lines[k].trim())
           lines.splice(k, 1)
           k -= 1

--- a/tests/compilers/tag-control-statements.test.js
+++ b/tests/compilers/tag-control-statements.test.js
@@ -259,4 +259,36 @@ describe('oval-control-statements', function () {
     var compiled = compiler.compile(content)
     expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
   })
+
+  it('compiles a statement with same child tag names', function () {
+    var content = `
+      <tag-name>
+        <div if={tag.value > 0}
+          class="test-class">
+          <div>
+            text
+          </div>
+        </div>
+      </tag-name>
+    `
+
+    var expectedCompiledCode = `
+      <tag-name>
+        {
+          tag.value > 0
+            ? (
+              <div class="test-class">
+                <div>
+                  text
+                </div>
+              </div>
+            )
+            : null
+        }
+      </tag-name>
+    `
+
+    var compiled = compiler.compile(content)
+    expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
+  })
 })

--- a/tests/oval/tag-directives.test.js
+++ b/tests/oval/tag-directives.test.js
@@ -5,17 +5,17 @@ describe('tag directives', function () {
   var Tag = function (tagName, root) {
     oval.BaseTag(this, tagName, root)
     this.injectDirectives({
-      augment1: function (tag) {
+      augment1: function (tag, directiveName) {
         return {
           preCreate: function (createElement, tagName, props, ...children) {
-            props.customValue = props['augment1']
+            props.customValue = props[directiveName]
           }
         }
       },
-      augment2: function (tag) {
+      augment2: function (tag, directiveName) {
         return {
           preCreate: function (createElement, tagName, props, ...children) {
-            props.customValue += props['augment2']
+            props.customValue += props[directiveName]
           }
         }
       }


### PR DESCRIPTION
This PR adds support for directives to self-reflect and use their name:

```
module.exports = function myDirective (tag, directiveName) {
  return {
    preCreate: function (...) {}
    postCreate: function (...) {}
  }
}
```