### PR TITLE
44 re implement child inner tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [major.minor.patch] - YYYY-MM-DD
 
+### Added
+
+- `BaseTag.morph()`
+- `BaseTag.updateinnerChildren(sourceEl)` - accepting optional source element
+
 ### Improved
 
 - `BaseTag.injectDirectives()` - every directive accepts `tag` and `directiveName`
 - each loop tests
+- Components with child components rendering
+- Components events
+- `BaseTag.updateAttributes(sourceEl)` - accepts optional source element
+- `BaseTag.updateProps(sourceEl)` - accepts optional source element
+- `BaseTag.updateRefs(sourceEl)` - accepts optional source element
 
 ### Fixed
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     var i
     if (selector === '*') {
       for (i = 0; i < this.registeredTags.length; i++) {
-        var els = root.querySelectorAll(this.registeredTags[i].tagName)
+        var els = root.getElementsByTagName(this.registeredTags[i].tagName)
         if (els.length) {
           for (var k = 0; k < els.length; k++) {
             elements.push(els[k])

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -1,4 +1,34 @@
 var autoId = 0
+
+var equalObjs = function (oldObj, newObj) {
+  if (Object.keys(oldObj).length !== Object.keys(newObj).length) {
+    return false
+  }
+
+  for (var prop in oldObj) {
+    if (!newObj[prop]) {
+      return false
+    }
+    if (newObj[prop] !== oldObj[prop]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+var equalArrays = function (oldArray, newArray) {
+  if (oldArray.length !== newArray.length) {
+    return false
+  }
+  for (var i = 0; i < oldArray.length; i++) {
+    if (oldArray[i] !== newArray[i]) {
+      return false
+    }
+  }
+  return true
+}
+
 module.exports = function (oval) {
   return function (tag, tagName, rootEl, props) {
     tag.tagName = tagName
@@ -17,46 +47,46 @@ module.exports = function (oval) {
       constructed: true,
       mounted: false
     }
-    tag.innerChildren = []
-    while (tag.root.hasChildNodes()) {
-      tag.innerChildren.push(tag.root.removeChild(tag.root.firstChild))
+
+    tag.updateInnerChildren = function (source) {
+      source = source || this.root
+      this.innerChildren = []
+      while (source.hasChildNodes()) {
+        this.innerChildren.push(source.removeChild(source.firstChild))
+      }
     }
 
-    tag.updateAttributes = function () {
+    tag.updateAttributes = function (source) {
+      source = source || this.root
       this.attributes = {}
-      for (var i = 0; i < this.root.attributes.length; i++) {
-        var attr = this.root.attributes[i]
+      for (var i = 0; i < source.attributes.length; i++) {
+        var attr = source.attributes[i]
         var name = attr.name
         if (name.indexOf('prop-') === 0 || name.indexOf('on') === 0) continue
         this.attributes[name] = attr.value
       }
     }
 
-    tag.updateProps = function () {
+    tag.updateProps = function (source) {
+      source = source || this.root
       this.props = {}
-      if (this.root.customProperties) {
-        for (var i = 0; i < this.root.customProperties.length; i++) {
-          var prop = this.root.customProperties[i]
+      if (source.customProperties) {
+        for (var i = 0; i < source.customProperties.length; i++) {
+          var prop = source.customProperties[i]
           this.props[prop.name] = prop.value
         }
       }
     }
 
-    tag.updateRefs = function () {
+    tag.updateRefs = function (source) {
+      source = source || this.root
       this.refs = {}
-      var refEls = this.root.querySelectorAll('[ref]')
+      var refEls = source.querySelectorAll('[ref]')
       for (var i = 0; i < refEls.length; i++) {
         var el = refEls[i]
         this.refs[el.attributes.ref.value] = el
       }
     }
-
-    if (!props) {
-      tag.updateProps()
-    }
-    tag.updateAttributes()
-
-    tag.createElement = oval.createElement()
 
     tag.injectDirectives = function (directivesMap) {
       var argumentedDirectives = {}
@@ -68,11 +98,39 @@ module.exports = function (oval) {
       this.createElement = oval.createElement(argumentedDirectives)
     }
 
+    tag.morph = function (source) {
+      if (!this.shouldRender) {
+        return
+      }
+      var oldProps = this.props
+      var oldAttributes = this.attributes
+      var oldInnerChildren = this.innerChildren
+
+      this.updateProps(source)
+      this.updateAttributes(source)
+      this.updateInnerChildren(source)
+
+      var needsUpdate = false
+      if (!equalObjs(oldProps, this.props)) {
+        needsUpdate = true
+      }
+      if (!equalObjs(oldAttributes, this.attributes)) {
+        needsUpdate = true
+      }
+      if (!equalArrays(oldInnerChildren, this.innerChildren)) {
+        needsUpdate = true
+      }
+      if (needsUpdate) {
+        this.update()
+      }
+    }
+
     tag.update = function () {
       if (!this.shouldRender) {
         return
       }
 
+      this.emit('render')
       this.view = this.render(this.createElement)
       if (!this.keepTagName) {
         this.view = this.view.firstChild
@@ -84,6 +142,7 @@ module.exports = function (oval) {
 
       this.emit('update')
       this.root = oval.updateElement(this.root, this.view)
+      this.root.oval_tag = this
 
       var newTags = oval.mountAll('*', this.root)
       for (var i = 0; i < this.childTags.length; i++) {
@@ -145,5 +204,15 @@ module.exports = function (oval) {
         type: eventName
       }, handler)
     }
+
+    // initialize props, innerChildren, attributes
+    if (!props) {
+      tag.updateProps()
+    }
+    tag.updateInnerChildren()
+    tag.updateAttributes()
+    tag.updateInnerChildren()
+
+    tag.createElement = oval.createElement()
   }
 }

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -1,4 +1,5 @@
 var autoId = 0
+var tagEvents = ['render', 'update', 'mount', 'updated', 'mounted', 'unmount', 'unmounted']
 
 var equalObjs = function (oldObj, newObj) {
   if (Object.keys(oldObj).length !== Object.keys(newObj).length) {
@@ -39,6 +40,7 @@ module.exports = function (oval) {
     tag.attributes = {}
     tag.childTags = []
     tag.refs = {}
+    tag.events = {}
     tag.id = autoId++
     tag.keepTagName = true
     tag.shouldRender = true
@@ -48,40 +50,40 @@ module.exports = function (oval) {
       mounted: false
     }
 
-    tag.updateInnerChildren = function (source) {
-      source = source || this.root
+    tag.updateInnerChildren = function (sourceEl) {
+      sourceEl = sourceEl || this.root
       this.innerChildren = []
-      while (source.hasChildNodes()) {
-        this.innerChildren.push(source.removeChild(source.firstChild))
+      while (sourceEl.hasChildNodes()) {
+        this.innerChildren.push(sourceEl.removeChild(sourceEl.firstChild))
       }
     }
 
-    tag.updateAttributes = function (source) {
-      source = source || this.root
+    tag.updateAttributes = function (sourceEl) {
+      sourceEl = sourceEl || this.root
       this.attributes = {}
-      for (var i = 0; i < source.attributes.length; i++) {
-        var attr = source.attributes[i]
+      for (var i = 0; i < sourceEl.attributes.length; i++) {
+        var attr = sourceEl.attributes[i]
         var name = attr.name
         if (name.indexOf('prop-') === 0 || name.indexOf('on') === 0) continue
         this.attributes[name] = attr.value
       }
     }
 
-    tag.updateProps = function (source) {
-      source = source || this.root
+    tag.updateProps = function (sourceEl) {
+      sourceEl = sourceEl || this.root
       this.props = {}
-      if (source.customProperties) {
-        for (var i = 0; i < source.customProperties.length; i++) {
-          var prop = source.customProperties[i]
+      if (sourceEl.customProperties) {
+        for (var i = 0; i < sourceEl.customProperties.length; i++) {
+          var prop = sourceEl.customProperties[i]
           this.props[prop.name] = prop.value
         }
       }
     }
 
-    tag.updateRefs = function (source) {
-      source = source || this.root
+    tag.updateRefs = function (sourceEl) {
+      sourceEl = sourceEl || this.root
       this.refs = {}
-      var refEls = source.querySelectorAll('[ref]')
+      var refEls = sourceEl.querySelectorAll('[ref]')
       for (var i = 0; i < refEls.length; i++) {
         var el = refEls[i]
         this.refs[el.attributes.ref.value] = el
@@ -98,7 +100,7 @@ module.exports = function (oval) {
       this.createElement = oval.createElement(argumentedDirectives)
     }
 
-    tag.morph = function (source) {
+    tag.morph = function (sourceEl) {
       if (!this.shouldRender) {
         return
       }
@@ -106,9 +108,9 @@ module.exports = function (oval) {
       var oldAttributes = this.attributes
       var oldInnerChildren = this.innerChildren
 
-      this.updateProps(source)
-      this.updateAttributes(source)
-      this.updateInnerChildren(source)
+      this.updateProps(sourceEl)
+      this.updateAttributes(sourceEl)
+      this.updateInnerChildren(sourceEl)
 
       var needsUpdate = false
       if (!equalObjs(oldProps, this.props)) {
@@ -130,14 +132,14 @@ module.exports = function (oval) {
         return
       }
 
+      if (!this.lifecycle.mounted) {
+        this.emit('mount')
+      }
+
       this.emit('render')
       this.view = this.render(this.createElement)
       if (!this.keepTagName) {
         this.view = this.view.firstChild
-      }
-
-      if (!this.lifecycle.mounted) {
-        this.emit('mount')
       }
 
       this.emit('update')
@@ -180,6 +182,7 @@ module.exports = function (oval) {
     }
 
     tag.emit = function (eventName, eventData, bubbles) {
+      if (!this.events[eventName]) return
       return this.plasma.emit({
         type: eventName,
         eventData: eventData,
@@ -188,18 +191,38 @@ module.exports = function (oval) {
     }
 
     tag.once = function (eventName, handler) {
+      if (tagEvents.indexOf(eventName) !== -1) {
+        if (!this.events[eventName]) this.events[eventName] = 0
+        this.events[eventName] += 1
+      }
       return this.plasma.once({
         type: eventName
-      }, handler)
+      }, (e) => {
+        this.events[eventName] -= 1
+        if (this.events[eventName] === 0) {
+          delete this.events[eventName]
+        }
+        handler(e)
+      })
     }
 
     tag.on = function (eventName, handler) {
+      if (tagEvents.indexOf(eventName) !== -1) {
+        if (!this.events[eventName]) this.events[eventName] = 0
+        this.events[eventName] += 1
+      }
       return this.plasma.on({
         type: eventName
       }, handler)
     }
 
     tag.off = function (eventName, handler) {
+      if (this.events[eventName]) {
+        this.events[eventName] -= 1
+        if (this.events[eventName] === 0) {
+          delete this.events[eventName]
+        }
+      }
       this.plasma.off({
         type: eventName
       }, handler)

--- a/lib/update-element.js
+++ b/lib/update-element.js
@@ -13,8 +13,10 @@ module.exports = function updateElement (node, nodeTemplate, opts) {
   // that can be set via attributes
   function copier (f, t) {
     if (f.oval_tag && f !== node) {
+      if (f.oval_tag.shouldRender) {
+        f.oval_tag.morph(t)
+      }
       // do not update element when its a child tag instance
-      f.oval_tag.morph(t)
       return false
     }
 

--- a/lib/update-element.js
+++ b/lib/update-element.js
@@ -12,8 +12,9 @@ module.exports = function updateElement (node, nodeTemplate, opts) {
   // morphdom only copies attributes. we decided we also wanted to copy events
   // that can be set via attributes
   function copier (f, t) {
-    // do not update element when its a tag which shouldn't not be rendered
-    if (f.oval_tag && !f.oval_tag.shouldRender) {
+    if (f.oval_tag && f !== node) {
+      // do not update element when its a child tag instance
+      f.oval_tag.morph(t)
       return false
     }
 


### PR DESCRIPTION
## Added

- `BaseTag.morph()`
- `BaseTag.updateinnerChildren(sourceEl)` - accepting optional source element

## Improved

- Components with child components rendering
- Components events
- `BaseTag.updateAttributes(sourceEl)` - accepts optional source element
- `BaseTag.updateProps(sourceEl)` - accepts optional source element
- `BaseTag.updateRefs(sourceEl)` - accepts optional source element