### PR TITLE
48 refactor basetag render method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [major.minor.patch] - YYYY-MM-DD
 
+- refactor `BaseTag.render` method
+
+## [3.1.0] - 2016-08-05
+
 ### Added
 
 - `BaseTag.morph()`

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   mountAt: function (el, tagName, props) {
     if (!el || !tagName) throw new Error(arguments + ' supplied should have el and tagName')
-    if (el.oval_tag) {
+    if (el.oval_tag && el.tagName === tagName.toUpperCase()) {
       el.oval_tag.update()
       return el.oval_tag
     }

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -39,11 +39,9 @@ module.exports.compile = function (content) {
       oval.BaseTag(this, tagName, root, props)
       var tag = this
       ${scriptContent.trim()}
-    }
-
-    render (createElement) {
-      var tag = this
-      return ${htmlContent.trim()}
+      this.render = function (createElement) {
+        return ${htmlContent.trim()}
+      }
     }
   }
   oval.registerTag('${tagName}', Tag)

--- a/tests/compilers/tag-file.test.js
+++ b/tests/compilers/tag-file.test.js
@@ -14,13 +14,11 @@ describe('oval-compiler', function () {
       oval.BaseTag(this, tagName, root, props)
       var tag = this
       var constructorCode = true
-    }
-
-    render (createElement) {
-      var tag = this
-      return <tag-name>
-    <h1>html test</h1>
-  </tag-name>
+      this.render = function (createElement) {
+        return <tag-name>
+          <h1>html test</h1>
+        </tag-name>
+      }
     }
   }
   oval.registerTag('tag-name', Tag)
@@ -28,6 +26,6 @@ describe('oval-compiler', function () {
 `
 
     var compiled = compiler.compile(content)
-    expect(compiled.trim()).to.eq(expectedCompiledCode.trim())
+    expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
   })
 })


### PR DESCRIPTION
With this PR one can write `.tag` files allowing usage of private tag variables:

```
<my-tag>
  <script>
     var myPrivateVariable = 1
     tag.myPublicVariable = 2
  </script>
  <span>{myPrivateVariable} && {tag.myPublicVariable}</span>
</my-tag>
```

So the following will work:

```
<my-parent-tag>
  <script>
     tag.on('mounted', function () {
        console.log(tag.refs.myTagReference.myPrivateVariable) // undefined
        console.log(tag.refs.myTagReference.myPublicVariable) // 2
     })
  </script>
  <my-tag ref='myTagReference' />
</my-parent-tag>
```