### PR TITLE
allow setting morphdom options per tag instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [major.minor.patch] - YYYY-MM-DD
 
+### Added
+- allow every tag instance to pass custom morphdom options via `tag.morphOptions`
+
+### Improved
 - refactor `BaseTag.render` method
 
 ## [3.1.0] - 2016-08-05

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
   },
   mountAt: function (el, tagName, props) {
     if (!el || !tagName) throw new Error(arguments + ' supplied should have el and tagName')
-    if (el.oval_tag && el.tagName === tagName.toUpperCase()) {
+    if (el.oval_tag) {
       el.oval_tag.update()
       return el.oval_tag
     }

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -143,7 +143,7 @@ module.exports = function (oval) {
       }
 
       this.emit('update')
-      this.root = oval.updateElement(this.root, this.view)
+      this.root = oval.updateElement(this.root, this.view, this.morphOptions)
       this.root.oval_tag = this
 
       var newTags = oval.mountAll('*', this.root)

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -234,6 +234,7 @@ module.exports = function (oval) {
     }
     tag.updateInnerChildren()
     tag.updateAttributes()
+    tag.updateInnerChildren()
 
     tag.createElement = oval.createElement()
   }

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -39,9 +39,11 @@ module.exports.compile = function (content) {
       oval.BaseTag(this, tagName, root, props)
       var tag = this
       ${scriptContent.trim()}
-      this.render = function (createElement) {
-        return ${htmlContent.trim()}
-      }
+    }
+
+    render (createElement) {
+      var tag = this
+      return ${htmlContent.trim()}
     }
   }
   oval.registerTag('${tagName}', Tag)

--- a/tests/compilers/tag-file.test.js
+++ b/tests/compilers/tag-file.test.js
@@ -14,11 +14,13 @@ describe('oval-compiler', function () {
       oval.BaseTag(this, tagName, root, props)
       var tag = this
       var constructorCode = true
-      this.render = function (createElement) {
-        return <tag-name>
-          <h1>html test</h1>
-        </tag-name>
-      }
+    }
+
+    render (createElement) {
+      var tag = this
+      return <tag-name>
+    <h1>html test</h1>
+  </tag-name>
     }
   }
   oval.registerTag('tag-name', Tag)
@@ -26,6 +28,6 @@ describe('oval-compiler', function () {
 `
 
     var compiled = compiler.compile(content)
-    expect(compiled.trim().replace(/ /g, '').replace(/\n/g, '')).to.eq(expectedCompiledCode.trim().replace(/ /g, '').replace(/\n/g, ''))
+    expect(compiled.trim()).to.eq(expectedCompiledCode.trim())
   })
 })


### PR DESCRIPTION
With this PR one will be able to do the following per every custom tag:

```
<my-tag>
  <script>
    this.morphOptions = {
       getNodeKey : function (node) { return node.getAttribute('oid') }
    }
  </script>
</my-tag>
```

For more details about available morphdom options see https://github.com/patrick-steele-idem/morphdom#morphdomfromnode-tonode-options--node