### PR TITLE
remove updateInnerChildren() duplication

### DIFF
--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -234,7 +234,6 @@ module.exports = function (oval) {
     }
     tag.updateInnerChildren()
     tag.updateAttributes()
-    tag.updateInnerChildren()
 
     tag.createElement = oval.createElement()
   }


### PR DESCRIPTION
Remove `updateInnerChildren()` duplication in `BaseTag`