### PR TITLE
Update boolean attributes parsing in create-element

### DIFF
--- a/lib/create-element.js
+++ b/lib/create-element.js
@@ -62,8 +62,13 @@ var createElement = function (tag, props, ...children) {
 
       // If a property is boolean, set itself to the key
       if (BOOL_PROPS[key]) {
-        if (val === 'true') val = key
-        else if (val === 'false') continue
+        if (val && val !== 'false') {
+          val = key
+        }
+        else {
+          // do not set the attribute
+          continue
+        }
       }
       if (p.slice(0, 5) === 'prop-') {
         var propName = p.slice(5)


### PR DESCRIPTION
Updated `create-element`:

When there is an attribute from the `BOOL_PROPS` list, check its value properly (no supporting bool and string (`'true` and `false`)). If the value is `false` or `'false'`, do not set the attribute to the element.