### PR TITLE
fix: BaseTag `update` event is fired after tag props/attrs are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [major.minor.patch] - YYYY-MM-DD
+
+### Fixed
+
+- BaseTag `update` event is fired after tag props/attrs are updated
+
 ## [4.0.0] - 2016-08-13
 
 ### API CHANGES

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -54,9 +54,9 @@ module.exports = function (oval) {
       if (!this.shouldRender) {
         return
       }
-      this.emit('update')
       this.props = props || this.props
       this.attrs = attrs || this.attrs
+      this.emit('update')
       this.childTags = []
       if (incrementalRender) {
         this.innerChildren = incrementalRender


### PR DESCRIPTION
With this PR we move the `update` event after re-assigning updated props/attrs values, so that upon `update` even one can change them and that change can be used within rendering phase.