### PR TITLE
64 directives postcreate is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - BaseTag `update` event is fired after tag props/attrs are updated
+- Oval Directives `postCreate` is not triggered
+
+### Improved
+
+- Oval Directives `postCreate(el, value)`
+- Oval Directives automatically delete directive's property once consumed
+- Oval Directives README section
 
 ## [4.0.0] - 2016-08-13
 

--- a/README.md
+++ b/README.md
@@ -357,8 +357,9 @@ module.exports = function (tag, directiveName) {
     preCreate: function (createElement, tagName, props, ...children) {
       // ... augment props
       // optionally return new array of children instead of given ones using createElement Fn
+      var directiveValue = props[directiveName]
     },
-    postCreate: function (el) {
+    postCreate: function (el, directiveValue) {
       // ... augment `el` dom element
     }
   }

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -45,13 +45,26 @@ function parseAttrsObj (attrsObj) {
 
 module.exports = function (tag, oval, directives) {
   var createElementWithDirectives = function (tagName, props, ...children) {
+    var postCreateDirectives
     if (props) {
       for (var p in directives) {
-        if (typeof props[p] !== 'undefined' && directives[p].preCreate) {
-          var resultedChilds = directives[p].preCreate(createElementWithDirectives, tagName, props, ...children)
-          if (resultedChilds) {
-            children = resultedChilds
+        if (typeof props[p] !== 'undefined') {
+          // buffer to postCreateDirectives
+          if (directives[p].postCreate) {
+            postCreateDirectives = postCreateDirectives || []
+            postCreateDirectives.push({d: directives[p], value: props[p]})
           }
+
+          if (directives[p].preCreate) {
+            // trigger preCreate of the directive
+            var resultedChilds = directives[p].preCreate(createElementWithDirectives, tagName, props, ...children)
+            if (resultedChilds) {
+              children = resultedChilds
+            }
+          }
+
+          // automatically remove the directive prop if present
+          delete props[p]
         }
       }
     }
@@ -93,6 +106,12 @@ module.exports = function (tag, oval, directives) {
           instance.mount(children)
           IncrementalDOM.elementClose(tagName)
           tag.childTags.push(instance)
+          // trigger post create directives if any
+          if (postCreateDirectives) {
+            for (var i = 0; i < postCreateDirectives.length; i++) {
+              postCreateDirectives[i].d.postCreate(createdElement, postCreateDirectives[i].value)
+            }
+          }
           return
         }
       }
@@ -128,11 +147,10 @@ module.exports = function (tag, oval, directives) {
 
       if (tagName !== 'virtual') {
         createdElement = IncrementalDOM.elementClose(tagName)
-        if (props) {
-          for (var p in directives) {
-            if (typeof props[p] !== 'undefined' && directives[p].postCreate) {
-              directives[p].postCreate(createdElement)
-            }
+        // trigger post create directives if any
+        if (postCreateDirectives) {
+          for (var k = 0; k < postCreateDirectives.length; k++) {
+            postCreateDirectives[k].d.postCreate(createdElement, postCreateDirectives[k].value)
           }
         }
       }

--- a/tests/oval/base-tag.test.js
+++ b/tests/oval/base-tag.test.js
@@ -109,7 +109,7 @@ describe('base-tag', function () {
     oval.mountAt(el, 'custom-tag-with-directives')
     var target = el.children[0]
     expect(target.attributes.class.value).to.eq('test')
-    expect(target.attributes.test.value).to.eq('')
+    expect(target.attributes.test).to.not.exist
     expect(target.attributes.custom.value).to.eq('value')
   })
 

--- a/tests/oval/tag-directives.test.js
+++ b/tests/oval/tag-directives.test.js
@@ -18,6 +18,9 @@ describe('tag directives', function () {
         return {
           preCreate: function (createElement, tagName, props, ...children) {
             props.customValue += props[directiveName]
+          },
+          postCreate: function (el) {
+            el.setAttribute('postCreated', 'true')
           }
         }
       }
@@ -58,6 +61,7 @@ describe('tag directives', function () {
     document.body.appendChild(el)
     var tag = oval.mountAt(el, 'custom-tag', {}, {'augment1': '4', 'augment2': '2'})
     expect(el.children[0].getAttribute('customValue')).to.eq('42')
+    expect(el.children[0].getAttribute('postCreated')).to.eq('true')
     customTagInstance = tag
   })
 


### PR DESCRIPTION
# What's done

## fixed

- oval directive `postCreate` hook for child tags

## improved

- oval directives automatically clean up directive's prop 
- `postCreate` hook for oval directives accepts directive's prop value