### PR TITLE
Fix root attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - BaseTag `update` event is fired after tag props/attrs are updated
+- Oval Directives `postCreate` is not triggered
+
+### Improved
+
+- Oval Directives `postCreate(el, value)`
+- Oval Directives automatically delete directive's property once consumed
+- Oval Directives README section
 
 ## [4.0.0] - 2016-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - BaseTag `update` event is fired after tag props/attrs are updated
 - Oval Directives `postCreate` is not triggered
+- Set root attributes only for compiled tag files
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [major.minor.patch] - YYYY-MM-DD
+
+### Fixed
+
+- BaseTag `update` event is fired after tag props/attrs are updated
+
 ## [4.0.0] - 2016-08-13
 
 ### API CHANGES

--- a/README.md
+++ b/README.md
@@ -357,8 +357,9 @@ module.exports = function (tag, directiveName) {
     preCreate: function (createElement, tagName, props, ...children) {
       // ... augment props
       // optionally return new array of children instead of given ones using createElement Fn
+      var directiveValue = props[directiveName]
     },
-    postCreate: function (el) {
+    postCreate: function (el, directiveValue) {
       // ... augment `el` dom element
     }
   }

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -54,9 +54,9 @@ module.exports = function (oval) {
       if (!this.shouldRender) {
         return
       }
-      this.emit('update')
       this.props = props || this.props
       this.attrs = attrs || this.attrs
+      this.emit('update')
       this.childTags = []
       if (incrementalRender) {
         this.innerChildren = incrementalRender

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -33,9 +33,6 @@ module.exports = function (oval) {
 
     tag.mount = function (incrementalRender) {
       this.root.setAttribute('cid', this.id)
-      for (var key in this.attributes) {
-        this.root.setAttribute(key, this.attributes[key])
-      }
       this.emit('mount')
       this.emit('update')
       this.childTags = []

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -53,9 +53,8 @@ module.exports.compile = function (content) {
     constructor (root, props, attrs) {
       var tag = this
       var tagAttrs = ${JSON.stringify(tagInfo.tagAttributes)}
-      attrs = attrs || {}
       for (var key in tagAttrs) {
-        attrs[key] = attrs[key] || tagAttrs[key]
+        root.setAttribute(key, tagAttrs[key])
       }
       oval.BaseTag(tag, root, props, attrs)
       ${scriptContent.trim()}

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -45,13 +45,26 @@ function parseAttrsObj (attrsObj) {
 
 module.exports = function (tag, oval, directives) {
   var createElementWithDirectives = function (tagName, props, ...children) {
+    var postCreateDirectives
     if (props) {
       for (var p in directives) {
-        if (typeof props[p] !== 'undefined' && directives[p].preCreate) {
-          var resultedChilds = directives[p].preCreate(createElementWithDirectives, tagName, props, ...children)
-          if (resultedChilds) {
-            children = resultedChilds
+        if (typeof props[p] !== 'undefined') {
+          // buffer to postCreateDirectives
+          if (directives[p].postCreate) {
+            postCreateDirectives = postCreateDirectives || []
+            postCreateDirectives.push({d: directives[p], value: props[p]})
           }
+
+          if (directives[p].preCreate) {
+            // trigger preCreate of the directive
+            var resultedChilds = directives[p].preCreate(createElementWithDirectives, tagName, props, ...children)
+            if (resultedChilds) {
+              children = resultedChilds
+            }
+          }
+
+          // automatically remove the directive prop if present
+          delete props[p]
         }
       }
     }
@@ -93,6 +106,12 @@ module.exports = function (tag, oval, directives) {
           instance.mount(children)
           IncrementalDOM.elementClose(tagName)
           tag.childTags.push(instance)
+          // trigger post create directives if any
+          if (postCreateDirectives) {
+            for (var i = 0; i < postCreateDirectives.length; i++) {
+              postCreateDirectives[i].d.postCreate(createdElement, postCreateDirectives[i].value)
+            }
+          }
           return
         }
       }
@@ -128,11 +147,10 @@ module.exports = function (tag, oval, directives) {
 
       if (tagName !== 'virtual') {
         createdElement = IncrementalDOM.elementClose(tagName)
-        if (props) {
-          for (var p in directives) {
-            if (typeof props[p] !== 'undefined' && directives[p].postCreate) {
-              directives[p].postCreate(createdElement)
-            }
+        // trigger post create directives if any
+        if (postCreateDirectives) {
+          for (var k = 0; k < postCreateDirectives.length; k++) {
+            postCreateDirectives[k].d.postCreate(createdElement, postCreateDirectives[k].value)
           }
         }
       }

--- a/tests/compilers/tag-file.test.js
+++ b/tests/compilers/tag-file.test.js
@@ -13,9 +13,8 @@ describe('oval-compiler', function () {
     constructor (root, props, attrs) {
       var tag = this
       var tagAttrs = {}
-      attrs = attrs || {}
       for (var key in tagAttrs) {
-        attrs[key] = attrs[key] || tagAttrs[key]
+        root.setAttribute(key, tagAttrs[key])
       }
       oval.BaseTag(tag, root, props, attrs)
       var constructorCode = true

--- a/tests/oval/base-tag.test.js
+++ b/tests/oval/base-tag.test.js
@@ -109,7 +109,7 @@ describe('base-tag', function () {
     oval.mountAt(el, 'custom-tag-with-directives')
     var target = el.children[0]
     expect(target.attributes.class.value).to.eq('test')
-    expect(target.attributes.test.value).to.eq('')
+    expect(target.attributes.test).to.not.exist
     expect(target.attributes.custom.value).to.eq('value')
   })
 

--- a/tests/oval/tag-directives.test.js
+++ b/tests/oval/tag-directives.test.js
@@ -18,6 +18,9 @@ describe('tag directives', function () {
         return {
           preCreate: function (createElement, tagName, props, ...children) {
             props.customValue += props[directiveName]
+          },
+          postCreate: function (el) {
+            el.setAttribute('postCreated', 'true')
           }
         }
       }
@@ -43,6 +46,24 @@ describe('tag directives', function () {
     return createElement('div', this.attributes)
   }
 
+  var TagWithChildTag = function (root, props, attrs) {
+    oval.BaseTag(this, root, props, attrs)
+    this.injectDirectives({
+      augmentFromParent: function (tag, directiveName) {
+        return {
+          postCreate: function (el, value) {
+            el.setAttribute('postCreatedByParent', value)
+          }
+        }
+      }
+    })
+  }
+  TagWithChildTag.prototype.render = function (createElement) {
+    return createElement('custom-tag', {
+      augmentFromParent: 'value42'
+    })
+  }
+
   before(function () {
     window.document.body.innerHTML = ''
     var plasma = {}
@@ -51,6 +72,7 @@ describe('tag directives', function () {
     oval.init(plasma)
     oval.registerTag('custom-tag', Tag)
     oval.registerTag('custom-tag-with-new-children', TagWithNewChildren)
+    oval.registerTag('custom-tag-with-child-tag', TagWithChildTag)
   })
 
   it('mount and renders', function () {
@@ -58,6 +80,7 @@ describe('tag directives', function () {
     document.body.appendChild(el)
     var tag = oval.mountAt(el, 'custom-tag', {}, {'augment1': '4', 'augment2': '2'})
     expect(el.children[0].getAttribute('customValue')).to.eq('42')
+    expect(el.children[0].getAttribute('postCreated')).to.eq('true')
     customTagInstance = tag
   })
 
@@ -76,5 +99,13 @@ describe('tag directives', function () {
     oval.mountAt(el, 'custom-tag-with-new-children')
     expect(el.children.length).to.eq(1)
     expect(el.children[0].tagName).to.eq('DIV')
+  })
+
+  it('triggers postCreate on inner tags', function () {
+    var el = document.createElement('custom-tag-with-child-tag')
+    document.body.appendChild(el)
+    oval.mountAt(el, 'custom-tag-with-child-tag')
+    expect(el.children[0].getAttribute('postCreatedByParent')).to.eq('value42')
+    expect(el.children[0].getAttribute('augmentFromParent')).to.not.exist
   })
 })


### PR DESCRIPTION
This PR fixes the following scenario:


1. Given `my-component.tag`

  ```
  <my-component class='hello'>
    <inner attribute1={tag.attributes.attribute1} />
  </my-component>
  ```

2. When used

  ```
  <my-component attribute1='some-value' />
  ```

3. Will be rendered correctly as

  ```
  <my-component class='hello'>
     <inner attribute1='some-value' />
  </my-component>
  ```

----

Without the fix rendered `my-component` will contain the `attribute1` also.