### PR TITLE
Set root attributes only for compiled tag files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - BaseTag `update` event is fired after tag props/attrs are updated
 - Oval Directives `postCreate` is not triggered
+- Set root attributes only for compiled tag files
 
 ### Improved
 

--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -33,9 +33,6 @@ module.exports = function (oval) {
 
     tag.mount = function (incrementalRender) {
       this.root.setAttribute('cid', this.id)
-      for (var key in this.attributes) {
-        this.root.setAttribute(key, this.attributes[key])
-      }
       this.emit('mount')
       this.emit('update')
       this.childTags = []

--- a/lib/compilers/tag-file.js
+++ b/lib/compilers/tag-file.js
@@ -53,9 +53,8 @@ module.exports.compile = function (content) {
     constructor (root, props, attrs) {
       var tag = this
       var tagAttrs = ${JSON.stringify(tagInfo.tagAttributes)}
-      attrs = attrs || {}
       for (var key in tagAttrs) {
-        attrs[key] = attrs[key] || tagAttrs[key]
+        root.setAttribute(key, tagAttrs[key])
       }
       oval.BaseTag(tag, root, props, attrs)
       ${scriptContent.trim()}

--- a/tests/compilers/tag-file.test.js
+++ b/tests/compilers/tag-file.test.js
@@ -13,9 +13,8 @@ describe('oval-compiler', function () {
     constructor (root, props, attrs) {
       var tag = this
       var tagAttrs = {}
-      attrs = attrs || {}
       for (var key in tagAttrs) {
-        attrs[key] = attrs[key] || tagAttrs[key]
+        root.setAttribute(key, tagAttrs[key])
       }
       oval.BaseTag(tag, root, props, attrs)
       var constructorCode = true


### PR DESCRIPTION
This PR fixes the following scenario:


1. Given `my-component.tag`

  ```
  <my-component class='hello'>
    <inner attribute1={tag.attributes.attribute1} />
  </my-component>
  ```

2. When used

  ```
  <my-component attribute1='some-value' />
  ```

3. Will be rendered correctly as

  ```
  <my-component class='hello'>
     <inner attribute1='some-value' />
  </my-component>
  ```

----

Without the fix rendered `my-component` will contain the `attribute1` also.