### PR TITLE
fix freeze feature for inner children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - BaseTag `update` event is fired after tag props/attrs are updated
 - Oval Directives `postCreate` is not triggered
 - Set root attributes only for compiled tag files
+- `freeze`-ed dom elements with children
 
 ### Improved
 

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -143,7 +143,11 @@ module.exports = function (tag, oval, directives) {
           }
         }
       }
-      appendChild(children)
+
+      var hasNotRenderedChildren = createdElement && createdElement.children.length === 0 && children.length !== 0
+      if (hasNotRenderedChildren || !parsedAttrs.attrs['freeze']) {
+        appendChild(children)
+      }
 
       if (tagName !== 'virtual') {
         createdElement = IncrementalDOM.elementClose(tagName)


### PR DESCRIPTION
Having the following within a custom element/tag

```
<div freeze>
  <div ref='myDiv' />
</div>
```

On multiple `tag.update()` calls appends within the `freezed` dom element new `<div ref='myDiv' />` 

The reason is that when skipping a freezed dom element via incremental-dom *no children should be written/updated*.
