### PR TITLE
fix tag element or parent element removing

### DIFF
--- a/lib/base-tag.js
+++ b/lib/base-tag.js
@@ -74,10 +74,15 @@ module.exports = function (oval) {
         this.childTags[i].unmount(true)
       }
       if (!skipRootRemove) {
-        this.root.remove()
+        this.remove()
       }
       this.mounted = false
       this.emit('unmounted')
+    }
+
+    tag.remove = function (el) {
+      el = el || this.root
+      el.parentNode.removeChild(el)
     }
 
     tag.emit = function (eventName, eventData, bubbles) {


### PR DESCRIPTION
Added base-tag `remove` method, to be able to remove `tag.root` DOM element or it's parent element