### PR TITLE
add support for overriding rendered tagName via tag directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## *[4.1.2]* - YYYY-MM-DD
+## *[4.2.0]* - YYYY-MM-DD
 
 ### Fixed
 
 - BaseTag `update` method to properly assign `tag.attributes`
+
+### Added
+
+- `tagName(tagName, props)` support for directives which need to change rendered tagName
+
+### Improved
+
+- `README.md` with known issue 3
 
 ## [4.1.0] - 2016-08-25
 

--- a/README.md
+++ b/README.md
@@ -356,11 +356,17 @@ module.exports = function (tag, directiveName) {
   return {
     preCreate: function (createElement, tagName, props, ...children) {
       // ... augment props
-      // optionally return new array of children instead of given ones using createElement Fn
       var directiveValue = props[directiveName]
+      // optionally return new array of children instead of given ones using createElement Fn
+      // example: return [createElement('div'), createElement('my-component')]
     },
     postCreate: function (el, directiveValue) {
       // ... augment `el` dom element
+    },
+    tagName: function (tagName, props) {
+      // return different tagName value
+      var newTagNameValue = props[directiveName]
+      return newTagNameValue
     }
   }
 }
@@ -472,4 +478,20 @@ require('global-oval')(oval)
   <each item, index in {items}>
     <div cid={index}>{item}</div>
   </each>
+  ```
+
+3. conditional rendered sibling tags with same name should have `cid` so that incremental-dom can properly update them on changes
+
+  **Won't** work with conditional tags:
+
+  ```html
+  <div if={condition1}>...</div>
+  <div if={condition2}>...</div>
+  ```
+
+  *Will* work:
+
+  ```html
+  <div if={condition1} cid='value1'>...</div>
+  <div if={condition2} cid='value2'>...</div>
   ```

--- a/lib/incremental-create-element.js
+++ b/lib/incremental-create-element.js
@@ -46,6 +46,7 @@ function parseAttrsObj (attrsObj) {
 module.exports = function (tag, oval, directives) {
   var createElementWithDirectives = function (tagName, props, ...children) {
     var postCreateDirectives
+    var originalTagName
     if (props) {
       for (var p in directives) {
         if (typeof props[p] !== 'undefined') {
@@ -63,6 +64,11 @@ module.exports = function (tag, oval, directives) {
             }
           }
 
+          if (directives[p].tagName) {
+            originalTagName = tagName
+            tagName = directives[p].tagName(tagName, props)
+          }
+
           // automatically remove the directive prop if present
           delete props[p]
         }
@@ -71,11 +77,39 @@ module.exports = function (tag, oval, directives) {
 
     var parsedAttrs = parseAttrsObj(props)
 
+    var appendChild = function (childs) {
+      for (var i = 0; i < childs.length; i++) {
+        var node = childs[i]
+        if (node === null) continue
+        if (typeof node === 'number' ||
+          typeof node === 'boolean' ||
+          typeof node === 'string' ||
+          node instanceof Date ||
+          node instanceof RegExp) {
+          IncrementalDOM.text(node)
+          continue
+        }
+        if ((typeof node === 'undefined' || node === null)) {
+          IncrementalDOM.text('')
+          continue
+        }
+        if (Array.isArray(node)) {
+          appendChild(node)
+          continue
+        }
+        if (typeof node === 'function') {
+          node()
+        } else {
+          console.warn('found unknown node', node, tagName, props, children)
+        }
+      }
+    }
+
     return function () {
       var createdElement
-      if (tagName !== 'virtual') {
+      if (tagName !== 'virtual' || originalTagName) {
         // console.log('element open ->', tagName, parsedAttrs.key)
-        var TagClass = oval.getRegisteredTag(tagName)
+        var TagClass = oval.getRegisteredTag(originalTagName || tagName)
         if (!TagClass) {
           IncrementalDOM.elementOpenStart(tagName, parsedAttrs.key, parsedAttrs.staticAttrs)
           for (var key in parsedAttrs.attrs) {
@@ -113,34 +147,6 @@ module.exports = function (tag, oval, directives) {
             }
           }
           return
-        }
-      }
-
-      function appendChild (childs) {
-        for (var i = 0; i < childs.length; i++) {
-          var node = childs[i]
-          if (node === null) continue
-          if (typeof node === 'number' ||
-            typeof node === 'boolean' ||
-            typeof node === 'string' ||
-            node instanceof Date ||
-            node instanceof RegExp) {
-            IncrementalDOM.text(node)
-            continue
-          }
-          if ((typeof node === 'undefined' || node === null)) {
-            IncrementalDOM.text('')
-            continue
-          }
-          if (Array.isArray(node)) {
-            appendChild(node)
-            continue
-          }
-          if (typeof node === 'function') {
-            node()
-          } else {
-            console.warn('found unknown node', node, tagName, props, children)
-          }
         }
       }
 

--- a/tests/oval/tag-directive-tag-name.test.js
+++ b/tests/oval/tag-directive-tag-name.test.js
@@ -1,0 +1,52 @@
+describe('tag directive tagName', function () {
+  require('../env')()
+
+  var oval
+  var customTagInstance
+
+  var TagWithRenderDirective = function (root, props, attrs) {
+    oval.BaseTag(this, root, props, attrs)
+  }
+  TagWithRenderDirective.prototype.render = function (createElement) {
+    return createElement('div')
+  }
+
+  var Tag = function (root, props, attrs) {
+    oval.BaseTag(this, root, props, attrs)
+    this.injectDirectives({
+      'render-as': function (tag, directiveName) {
+        return {
+          tagName: function (tagName, props) {
+            return props[directiveName]
+          }
+        }
+      }
+    })
+  }
+  Tag.prototype.render = function (createElement) {
+    return createElement('custom-tag-with-render', {'render-as': 'button'})
+  }
+
+  before(function () {
+    window.document.body.innerHTML = ''
+    var plasma = {}
+    oval = require('../../index')
+    oval.registeredTags = []
+    oval.init(plasma)
+    oval.registerTag('custom-tag', Tag)
+    oval.registerTag('custom-tag-with-render', TagWithRenderDirective)
+  })
+
+  it('mount and renders', function () {
+    var tag = oval.appendAt(document.body, 'custom-tag')
+    expect(document.body.children[0].tagName).to.eq('CUSTOM-TAG')
+    expect(tag.root.children[0].tagName).to.eq('BUTTON')
+    customTagInstance = tag
+  })
+
+  it('re-renders', function () {
+    customTagInstance.update()
+    expect(customTagInstance.root.tagName).to.eq('CUSTOM-TAG')
+    expect(customTagInstance.root.children[0].tagName).to.eq('BUTTON')
+  })
+})


### PR DESCRIPTION
With this PR is added support for overriding tagName of custom tags like so:

```html
// in my-custom.tag
<my-custom-tag>
  <script>
     tag.injectDiretives({
       'render-as': function (oval, directiveName) {
          return {
            tagName: function (tagName, props) {
               return props[directiveName]
            }
          }
       }
     })
  </script>
</my-custom-tag>
```

```html
// in app.tag
<app>
  <table>
    <my-custom-tag render-as='tr' />
  </table>
  <ul>
    <my-custom-tag render-as='li' />
  </ul>
</app>
```